### PR TITLE
Add better interface for subscription updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  presets: [ "latest" ]
+}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ and it will print...
 
 Use the live directive to subscribe via an promise/iterator combo.
 
+
 ```
 const myQuery = gql`{
   fish {
@@ -92,9 +93,9 @@ const myQuery = gql`{
   }
 }`;
 
-const iter = graphqlGun(myQuery, gun)[Symbol.iterator]();
+const { next } = graphqlGun(myQuery, gun);
 
-console.log(await iter.next().value);
+console.log(await next());
 ```
 
 Will print...
@@ -114,7 +115,7 @@ Then try:
 ```
 gun.get('fish').get('red').put({name: 'bob'});
 
-console.log(await iter.next().value);
+console.log(await next());
 ```
 
 And you will get...
@@ -131,7 +132,10 @@ And you will get...
 
 Take a look at the tests to learn more.
 
+
+
 # With React
+
 
 Use the high order component for a Relay inspired API directly into your Gun DB.
 

--- a/index.js
+++ b/index.js
@@ -100,8 +100,10 @@ module.exports = function graphqlGun(query, gun) {
     triggerUpdate();
     return value;
   });
+  let iter = iterableObj();
+  result.next = () => iter.next().then(r => r.value);
   result[Symbol.iterator] = function() {
-    return iterableObj();
+    return iter;
   };
   return result;
 };

--- a/index.test.js
+++ b/index.test.js
@@ -12,12 +12,12 @@ describe("graphqlGun", () => {
     expect(
       await graphqlGun(
         gql`{
-      foo {
-        bar {
-          baz
-        }
-      }
-    }`,
+          foo {
+            bar {
+              baz
+            }
+          }
+        }`,
         gun
       )
     ).toMatchSnapshot();
@@ -28,13 +28,13 @@ describe("graphqlGun", () => {
 
     const results = await graphqlGun(
       gql`{
-      foo {
-        bar {
-          _chain
-          hello
+        foo {
+          bar {
+            _chain
+            hello
+          }
         }
-      }
-    }`,
+      }`,
       gun
     );
 
@@ -68,10 +68,10 @@ describe("graphqlGun", () => {
 
     const results = await graphqlGun(
       gql`{
-      things(type: Set) {
-        stuff
-      }
-    }`,
+        things(type: Set) {
+          stuff
+        }
+      }`,
       gun
     );
 
@@ -86,22 +86,20 @@ describe("graphqlGun", () => {
     gun.get("things").set(thing1);
     gun.get("things").set(thing2);
 
-    let iter = graphqlGun(
+    let { next } = graphqlGun(
       gql`{
-      things(type: Set) {
-        stuff @live
-      }
-    }`,
+        things(type: Set) {
+          stuff @live
+        }
+      }`,
       gun
-    )[Symbol.iterator]();
+    );
 
-    await iter.next();
-
-    expect(iter.value).toEqual({ things: [{ stuff: "b" }, { stuff: "c" }] });
+    expect(await next()).toEqual({ things: [{ stuff: "b" }, { stuff: "c" }] });
 
     gun.get("thing1").put({ stuff: "changed" });
 
-    expect((await iter.next()).value).toEqual({
+    expect(await next()).toEqual({
       things: [{ stuff: "changed" }, { stuff: "c" }]
     });
   });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "gun": "^0.6.7"
   },
   "devDependencies": {
+    "babel": "^6.23.0",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-latest": "^6.24.0",
     "graphql-tag": "^1.3.2",
     "jest": "^19.0.2",
     "prettier": "^0.22.0",


### PR DESCRIPTION
I got some feedback from @kristianmandrup about the promise iterator being less than easy to use. I added a wrapper around it inspired by `co.wrap`.