### PR TITLE
Rewrite to make subscriptions easier

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`graphqlGun can do the basics 1`] = `
 Object {
   "foo": Object {
     "bar": Object {
-      "baz": "baz",
+      "baz": "ping",
     },
   },
 }
@@ -15,7 +15,7 @@ Object {
   "foo": Object {
     "bar": Object {
       "_chain": undefined,
-      "hello": "pop",
+      "hello": "world",
     },
   },
 }

--- a/index.test.js
+++ b/index.test.js
@@ -7,7 +7,7 @@ const gun = Gun();
 
 describe("graphqlGun", () => {
   it("can do the basics", async () => {
-    gun.get("foo").put({ bar: "baz" });
+    gun.get("foo").put({ bar: { baz: "ping" } });
 
     expect(
       await graphqlGun(
@@ -24,7 +24,7 @@ describe("graphqlGun", () => {
   });
 
   it("lets you grab the chain at any point", async () => {
-    gun.get("foo").put({ bar: "pop" });
+    gun.get("foo").put({ bar: { hello: "world" } });
 
     const results = await graphqlGun(
       gql`{
@@ -44,8 +44,10 @@ describe("graphqlGun", () => {
       results.foo.bar._chain.on(
         (value, key) => {
           expect(key).toEqual("bar");
-          expect(value).toEqual("pop");
-          resolve();
+          if (value.some) {
+            expect(value.some).toEqual("stuff");
+            resolve();
+          }
         },
         { changed: true }
       );
@@ -82,7 +84,7 @@ describe("graphqlGun", () => {
     const thing1 = gun.get("thing1");
     const thing2 = gun.get("thing2");
     thing1.put({ stuff: "b", more: "ok" });
-    thing2.put({ stuff: "c", more: "ok" });
+    thing2.put({ stuff: "c", more: "two" });
     gun.get("things").set(thing1);
     gun.get("things").set(thing2);
 

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "test": "jest --watch"
   },
   "dependencies": {
-    "graphql-anywhere": "github:brysgo/graphql-anywhere#npm",
-    "gun": "^0.6.7"
+    "gun": "^0.6.7",
+    "traverse-async": "^0.1.6"
   },
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-latest": "^6.24.0",
-    "graphql-tag": "^2.0.0",
     "graphql": "^0.9.1",
+    "graphql-tag": "^2.0.0",
     "jest": "^19.0.2",
     "prettier": "^0.22.0",
     "react": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest --watch"
   },
   "dependencies": {
-    "traverse-async": "^0.1.6"
+    "traverse-async": "^0.1.6",
     "gun": "^0.7.0"
   },
   "devDependencies": {

--- a/react/__snapshots__/index.test.js.snap
+++ b/react/__snapshots__/index.test.js.snap
@@ -48,9 +48,9 @@ exports[`createContainer renders the fragment in the container 1`] = `
 >
   {
     "color": {
+      "hue": 255,
       "saturation": 255,
-      "value": 255,
-      "hue": 255
+      "value": 255
     }
   }
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,10 @@ ast-types@0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
 
+async@^0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
 async@^1.4.0, async@^1.4.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1124,8 +1128,9 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-"graphql-anywhere@file:./graphql-anywhere":
+"graphql-anywhere@github:brysgo/graphql-anywhere#npm":
   version "3.0.1"
+  resolved "https://codeload.github.com/brysgo/graphql-anywhere/tar.gz/0bbbb385c913c72d7a59876b5268d25ac96db727"
 
 graphql-tag@^2.0.0:
   version "2.0.0"
@@ -2409,6 +2414,12 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+traverse-async@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/traverse-async/-/traverse-async-0.1.6.tgz#8493ad4b2e7f548999c0df143a16de463908fddc"
+  dependencies:
+    async "^0.9.0"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I'd like to come back to `graphql-anywhere` once I can conceptually wrap my head around how I would do live queries, but for now, I rewrote graphql-gun to traverse the `graphql-tag` tree manually.